### PR TITLE
Add name property to the returned plugin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,7 @@ export default function filesize(options = {}, env) {
 	}
 
 	return {
+		name: "filesize",
 		ongenerate(bundle, { code }) {
 			console.log(getData(bundle, code));
 		}


### PR DESCRIPTION
If you provide it rollup might use it for some useful logs (in case of crash etc)