### PR TITLE
Output bundle/file names for when code splitting

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,14 +3,17 @@ import filesize from '../src';
 
 const x = filesize({}, "test");
 
-const code = 'function add(first, second) { return first + second; }';
+const bundle = {
+  fileName: 'bundled-file.js',
+  code: 'function add(first, second) { return first + second; }',
+};
 
 test('fileSize should return a string', t => {
-	t.is(typeof x({dest: 'abc.js'}, code), 'string');
+	t.is(typeof x({dest: 'abc.js'}, bundle), 'string');
 });
 
 test('fileSize should return correct string', t => {
-	t.true(x({dest: 'abc.js'}, code).indexOf('54') >= 0)
+	t.true(x({dest: 'abc.js'}, bundle).indexOf('54') >= 0)
 });
 
 test('fileSize should apply correct template', t => {
@@ -22,6 +25,6 @@ test('fileSize should apply correct template', t => {
 
 	const z = filesize(options, "test");
 	const expected = '49 B';
-	console.log(z({dest: 'abc.js'}, code))
-	t.is(z({dest: 'abc.js'}, code), expected)
+	console.log(z({dest: 'abc.js'}, bundle))
+	t.is(z({dest: 'abc.js'}, bundle), expected)
 });


### PR DESCRIPTION
This PR either outputs:
`Destination: <the outputOptions.file>` when _not_ code splitting or
`Bundle Name: <the bundle file name>` when code splitting.

I didn't raise an issue but when code splitting the `filesize` output was nameless!