### PR TITLE
Fix deep-assign deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "boxen": "^4.1.0",
     "brotli-size": "4.0.0",
     "colors": "^1.3.3",
-    "deep-assign": "^3.0.0",
     "filesize": "^4.1.2",
     "gzip-size": "^5.1.1",
+    "lodash.merge": "^4.6.2",
     "terser": "^4.1.3"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import fileSize from "filesize";
 import boxen from "boxen";
 import colors from "colors";
-import deepAssign from "deep-assign";
+import merge from "lodash.merge";
 import gzip from "gzip-size";
 import terser from "terser";
 
@@ -37,7 +37,7 @@ export default function filesize(options = {}, env) {
 		showMinifiedSize: true
 	};
 
-	let opts = deepAssign({}, defaultOptions, options);
+	let opts = merge({}, defaultOptions, options);
 	if (options.render) {
 		opts.render = options.render;
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1599,13 +1599,6 @@ decompress-response@^3.3.0:
   dependencies:
     mimic-response "^1.0.0"
 
-deep-assign@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/deep-assign/-/deep-assign-3.0.0.tgz#c8e4c4d401cba25550a2f0f486a2e75bc5f219a2"
-  integrity sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==
-  dependencies:
-    is-obj "^1.0.0"
-
 deep-equal@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
@@ -2432,7 +2425,7 @@ lodash.islength@^4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.islength/-/lodash.islength-4.0.1.tgz#4e9868d452575d750affd358c979543dc20ed577"
   integrity sha1-Tpho1FJXXXUK/9NYyXlUPcIO1Xc=
 
-lodash.merge@^4.6.1:
+lodash.merge@^4.6.1, lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==


### PR DESCRIPTION
Fixes #54 

`deep-assign` has been deprecated by the author. The author suggests to use either `lodash.merge` or `merge-options`. https://www.npmjs.com/package/deep-assign

I have swapped `deep-assign` out for `lodash.merge` in this PR.