### PR TITLE
feat: use "type === 'asset'"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,11 +77,8 @@ export default function filesize(options = {}, env) {
 			Object.keys(bundle)
 				.map(fileName => bundle[fileName])
 				.filter(currentBundle => {
-					if (
-						currentBundle.hasOwnProperty("type") &&
-						currentBundle.type !== "asset"
-					) {
-						return true;
+					if (currentBundle.hasOwnProperty("type")) {
+						return currentBundle.type !== "asset";
 					}
 					return !currentBundle.isAsset;
 				})

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,15 @@ export default function filesize(options = {}, env) {
 		generateBundle(outputOptions, bundle, isWrite) {
 			Object.keys(bundle)
 				.map(fileName => bundle[fileName])
-				.filter(currentBundle => !currentBundle.isAsset)
+				.filter(currentBundle => {
+					if (
+						currentBundle.hasOwnProperty("type") &&
+						currentBundle.type !== "asset"
+					) {
+						return true;
+					}
+					return !currentBundle.isAsset;
+				})
 				.forEach((currentBundle) => {
 					console.log(getData(outputOptions, currentBundle))
 				});

--- a/src/index.js
+++ b/src/index.js
@@ -15,9 +15,9 @@ function render(opt, outputOptions, info) {
 	const value = colors[secondaryColor];
 
 	const values = [
-    ...(outputOptions.file ?
-      [`${title("Destination: ")}${value(outputOptions.file)}`] :
-      (info.fileName ? [`${title("Bundle Name: ")} ${value(info.fileName)}`] : [])),
+		...(outputOptions.file ?
+			[`${title("Destination: ")}${value(outputOptions.file)}`] :
+			(info.fileName ? [`${title("Bundle Name: ")} ${value(info.fileName)}`] : [])),
 		...[`${title("Bundle Size: ")} ${value(info.bundleSize)}`],
 		...(info.minSize ? [`${title("Minified Size: ")} ${value(info.minSize)}`] : []),
 		...(info.gzipSize ? [`${title("Gzipped Size: ")} ${value(info.gzipSize)}`] : []),
@@ -43,10 +43,10 @@ export default function filesize(options = {}, env) {
 	}
 
 	const getData = function(outputOptions, bundle) {
-    const { code, fileName } = bundle;
-    const info = {};
+	const { code, fileName } = bundle;
+	const info = {};
 
-    info.fileName = fileName;
+	info.fileName = fileName;
 
 		info.bundleSize = fileSize(Buffer.byteLength(code), opts.format);
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,22 +1,22 @@
-import test from 'ava';
-import filesize from '../src';
+import test from "ava";
+import filesize from "../src";
 
 const x = filesize({}, "test");
 
 const bundle = {
-	fileName: 'bundled-file.js',
-	code: 'function add(first, second) { return first + second; }',
+	fileName: "bundled-file.js",
+	code: "function add(first, second) { return first + second; }",
 };
 
-test('fileSize should return a string', t => {
-	t.is(typeof x({dest: 'abc.js'}, bundle), 'string');
+test("fileSize should return a string", t => {
+	t.is(typeof x({dest: "abc.js"}, bundle), "string");
 });
 
-test('fileSize should return correct string', t => {
-	t.true(x({dest: 'abc.js'}, bundle).indexOf('54') >= 0)
+test("fileSize should return correct string", t => {
+	t.true(x({dest: "abc.js"}, bundle).indexOf("54") >= 0)
 });
 
-test('fileSize should apply correct template', t => {
+test("fileSize should apply correct template", t => {
 	const options = {
 		render: function (opts, bundle, { gzipSize }) {
 			return gzipSize;
@@ -24,7 +24,7 @@ test('fileSize should apply correct template', t => {
 	};
 
 	const z = filesize(options, "test");
-	const expected = '49 B';
-	console.log(z({dest: 'abc.js'}, bundle))
-	t.is(z({dest: 'abc.js'}, bundle), expected)
+	const expected = "49 B";
+	console.log(z({dest: "abc.js"}, bundle))
+	t.is(z({dest: "abc.js"}, bundle), expected)
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,8 +4,8 @@ import filesize from '../src';
 const x = filesize({}, "test");
 
 const bundle = {
-  fileName: 'bundled-file.js',
-  code: 'function add(first, second) { return first + second; }',
+	fileName: 'bundled-file.js',
+	code: 'function add(first, second) { return first + second; }',
 };
 
 test('fileSize should return a string', t => {


### PR DESCRIPTION
Resolve: https://github.com/ritz078/rollup-plugin-filesize/issues/57

I fixed an issue where `isAsset` was deprecated in rollup@1.21.0 and above.

## About

- I updated `isAsset` to `type === 'asset'`.
    - `isAsset` is deprecated in rollup@1.21.0 and high.
    - The `type` property does not exist for rollup@1.20.0 or under. So, if there is no `type`, use `isAsset`.
- Fixed indent and colon format.
    - Fixed space to tab, refer to `.editorconfig`.
    - Unified to double-quotation.
