### PR TITLE
Post render

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -64,6 +64,23 @@ filesize({
 })
 ```
 
+#### reporter
+type : `function`
+
+After rendering occurs, you may wish to pass on the collected file data,
+e.g., to build a badge for filesizes (as does [filesize-badger](https://github.com/brettz9/filesize-badger)).
+
+You can use `reporter` to do so:
+
+```js
+filesize({
+	reporter : function (options, bundle, { minSize, gzipSize, brotliSize, bundleSize }){
+		// If a promise is returned, it will be awaited before rendering.
+		return promise;
+	}
+})
+```
+
 #### theme
 type: `string`
 
@@ -77,5 +94,3 @@ choose based on your terminal theme.
 
 ## License
 MIT
-
-

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,7 +3,7 @@ import filesize from "./src/index";
 import pkg from "./package.json";
 
 export default {
-	external: Object.keys(pkg.dependencies),
+	external: ["fs", "util", ...Object.keys(pkg.dependencies)],
 	plugins: [
 		babel({
 			babelrc: false,

--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ export default function filesize(options = {}, env) {
 		format: {},
 		theme: "dark",
 		render: render,
-		postRender: null,
+		reporter: null,
 		showBeforeSizes: false,
 		showGzippedSize: true,
 		showBrotliSize: false,
@@ -135,8 +135,8 @@ export default function filesize(options = {}, env) {
 
 		const rendered = opts.render(opts, outputOptions, info);
 
-		if (opts.postRender) {
-			await opts.postRender(opts, outputOptions, info);
+		if (opts.reporter) {
+			await opts.reporter(opts, outputOptions, info);
 		}
 
 		return rendered;

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,15 @@
+import { readFile as origReadFile } from "fs";
+import { promisify } from "util";
+
 import fileSize from "filesize";
 import boxen from "boxen";
 import colors from "colors";
 import merge from "lodash.merge";
 import gzip from "gzip-size";
 import terser from "terser";
+import brotli from "brotli-size";
 
-const { readFile: origReadFile } = require("fs");
-const { promisify } = require("util");
 const readFile = promisify(origReadFile);
-
-const brotli = require("brotli-size");
 
 async function render(opt, outputOptions, info) {
 	const primaryColor = opt.theme === "dark" ? "green" : "black";
@@ -68,6 +68,7 @@ export default function filesize(options = {}, env) {
 		format: {},
 		theme: "dark",
 		render: render,
+		postRender: null,
 		showBeforeSizes: false,
 		showGzippedSize: true,
 		showBrotliSize: false,
@@ -132,7 +133,13 @@ export default function filesize(options = {}, env) {
 			}
 		}
 
-		return opts.render(opts, outputOptions, info);
+		const rendered = opts.render(opts, outputOptions, info);
+
+		if (opts.postRender) {
+			await opts.postRender(opts, outputOptions, info);
+		}
+
+		return rendered;
 	};
 
 	if (env === "test") {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -29,3 +29,17 @@ test("fileSize should apply correct template", async t => {
 	console.log(await z({ dest: "abc.js" }, bundle));
 	t.is(await z({ dest: "abc.js" }, bundle), expected);
 });
+
+test("fileSize should report size to postRender", async t => {
+	let size;
+	const options = {
+		postRender: function(opts, bundle, { gzipSize }) {
+			size = gzipSize;
+		}
+	};
+
+	const z = filesize(options, "test");
+	const expected = "49 B";
+	console.log(await z({ dest: "abc.js" }, bundle));
+	t.is(size, expected);
+});


### PR DESCRIPTION
Builds on #60 , #61, #62. Closes #63 . 

- feat: add `postRender` hook which can get at filesize `info` (as well as `opts` and `outputOptions`)

Although users could currently get this by implementing their own `render` function, if they want to keep the default rendering, they would need to reimplement all of it themselves. This allows them to keep the default `render` if they wish, as well as add a separate `postRender` hook (e.g., for building file size badges)