### PR TITLE
Testing

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -49,6 +49,8 @@ Whether to show [Brotli](https://www.wikiwand.com/en/Brotli) size or not
 
 #### showBeforeSizes
 
+**Note: this feature is experimental and may be changed in a future release.**
+
 type: `"release", ``"build"`, or `"none"`
 default: `"none"`
 

--- a/src/index.js
+++ b/src/index.js
@@ -31,13 +31,11 @@ export default function filesize(options = {}, env) {
 		if (showBeforeSizes !== "none") {
 			let file = outputOptions.file || outputOptions.dest;
 			if (showBeforeSizes !== "build") {
-				const { name, version } = await import(
-					join(process.cwd(), "./package.json")
-				);
+				const { name } = await import(join(process.cwd(), "./package.json"));
 				try {
 					const output = join(thisDirectory, "../.cache");
 					if (!existsSync(output)) {
-						await pacote.extract(`${name}@${version}`, output);
+						await pacote.extract(`${name}@latest`, output);
 					}
 					file = join(output, file);
 				} catch (err) {

--- a/src/reporters/boxen.js
+++ b/src/reporters/boxen.js
@@ -9,8 +9,12 @@ export default async function boxenReporter(opt, outputOptions, info) {
 	const value = colors[secondaryColor];
 
 	const values = [
-		...(outputOptions.file
-			? [`${title("Destination: ")}${value(outputOptions.file)}`]
+		...(outputOptions.file || outputOptions.dest
+			? [
+					`${title("Destination: ")}${value(
+						outputOptions.file || outputOptions.dest
+					)}`,
+			  ]
 			: info.fileName
 			? [`${title("Bundle Name: ")} ${value(info.fileName)}`]
 			: []),

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -166,18 +166,14 @@ test("fileSize should apply `showBeforeSizes` option", async (t) => {
 
 	t.regex(val, /Destination:/);
 
-	// When preparing a new version number, the version won't yet
-	//  exist on npm, so this will fail (though it will otherwise pass)
-	/*
 	if (colors.supportsColor()) {
 		// eslint-disable-next-line no-control-regex
 		t.regex(val, /\(was \u001b\[33m[\d.]+ KB/);
 	} else {
 		t.regex(val, /\(was [\d.]+ KB/);
 	}
-	*/
 
-	// Should at least recreate the `.cache` folder
+	// Should recreate the `.cache` folder
 	t.is(existsSync(".cache"), true);
 });
 
@@ -245,18 +241,14 @@ test("fileSize should apply `showBeforeSizes` option (with deprecated `dest`)", 
 
 	t.regex(val, /Destination:/);
 
-	// When preparing a new version number, the version won't yet
-	//  exist on npm, so this will fail (though it will otherwise pass)
-	/*
 	if (colors.supportsColor()) {
 		// eslint-disable-next-line no-control-regex
 		t.regex(val, /\(was \u001b\[33m[\d.]+ KB/);
 	} else {
 		t.regex(val, /\(was [\d.]+ KB/);
 	}
-	*/
 
-	// Should at least recreate the `.cache` folder
+	// Should recreate the `.cache` folder
 	t.is(existsSync(".cache"), true);
 });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,3 +1,4 @@
+import { existsSync } from "fs";
 import { promisify } from "util";
 import test from "ava";
 import rimRaf from "rimraf";
@@ -158,14 +159,26 @@ test("fileSize should generate a bundle", async (t) => {
 });
 
 test("fileSize should apply `showBeforeSizes` option", async (t) => {
+	await removeCacheDir();
+
 	const getLoggingData = filesize({ showBeforeSizes: "release" }, "test");
 	const val = await getLoggingData({ file: "./dist/index.js" }, bundle);
+
+	t.regex(val, /Destination:/);
+
+	// When preparing a new version number, the version won't yet
+	//  exist on npm, so this will fail (though it will otherwise pass)
+	/*
 	if (colors.supportsColor()) {
 		// eslint-disable-next-line no-control-regex
 		t.regex(val, /\(was \u001b\[33m[\d.]+ KB/);
 	} else {
 		t.regex(val, /\(was [\d.]+ KB/);
 	}
+	*/
+
+	// Should at least recreate the `.cache` folder
+	t.is(existsSync(".cache"), true);
 });
 
 test('fileSize should apply `showBeforeSizes` option as "build"', async (t) => {
@@ -181,7 +194,7 @@ test('fileSize should apply `showBeforeSizes` option as "build"', async (t) => {
 	}
 });
 
-test('fileSize should ignore before sizes with package-missing file and `showBeforeSizes: "release"`', async (t) => {
+test('fileSize should ignore before sizes with package missing file (test files not in release) and `showBeforeSizes: "release"`', async (t) => {
 	await removeCacheDir();
 
 	let getLoggingData = filesize({ showBeforeSizes: "release" }, "test");
@@ -225,14 +238,26 @@ test("fileSize should ignore before sizes with bad package", async (t) => {
 });
 
 test("fileSize should apply `showBeforeSizes` option (with deprecated `dest`)", async (t) => {
+	await removeCacheDir();
+
 	const getLoggingData = filesize({ showBeforeSizes: "release" }, "test");
 	const val = await getLoggingData({ dest: "./dist/index.js" }, bundle);
+
+	t.regex(val, /Destination:/);
+
+	// When preparing a new version number, the version won't yet
+	//  exist on npm, so this will fail (though it will otherwise pass)
+	/*
 	if (colors.supportsColor()) {
 		// eslint-disable-next-line no-control-regex
 		t.regex(val, /\(was \u001b\[33m[\d.]+ KB/);
 	} else {
 		t.regex(val, /\(was [\d.]+ KB/);
 	}
+	*/
+
+	// Should at least recreate the `.cache` folder
+	t.is(existsSync(".cache"), true);
 });
 
 test("fileSize should fallback to printing `fileName`", async (t) => {


### PR DESCRIPTION
Hi @ritz078 , 

This PR addresses the issue reported at https://github.com/ritz078/rollup-plugin-filesize/pull/68#discussion_r416883649 .

While preparing to update the tests for this, I noticed that the text message when the deprecated `dest` was used was not the same as that for `output.file` as I think it should be, so I adjusted that so the messages will be the same.

I also noticed that I should have been removing the cache directory for each `showBeforeSizes: "release"` test, so I also added that for the tests.

But the main fix here is for the case reported--when a version is being bumped but it has not yet been published. This is the use case you pointed out was not common during development, and while that is true, this shows it does at least happen at junctures such as this, and we need the tests to be adjusted accordingly to anticipate this even if it unfortunately means we can't test for the presence of the "was" text as a result).

- Fix: Use same boxen reporting output for `file` or deprecated `dest`
- Testing: Ensure cache directory is removed before testing all `showBeforeSizes: "release"` tests (besides one test checking for an existing cache)
- Testing: Avoid checking for "was (...)" test in positive-expecting `showBeforeSizes: "release"` tests (will not show when version has been bumped but not yet released)