### PR TITLE
- Windows compatibility for `import`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   "scripts": {
     "lint": "eslint .",
     "test": "nyc ava test/index.test.js",
-    "pretest": "rollup -c",
-    "prepublishOnly": "npm run test",
-    "prebuild": "rimraf dist/*"
+    "remove-dist": "rimraf dist/*",
+    "pretest": "npm run remove-dist && rollup -c",
+    "prepare": "npm run test"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,8 @@ const readFile = promisify(origReadFile);
 
 const thisDirectory = dirname(new URL(import.meta.url).pathname);
 
+const isWindows = process.platform === "win32";
+
 export default function filesize(options = {}, env) {
 	let {
 		render,
@@ -123,11 +125,26 @@ export default function filesize(options = {}, env) {
 						let p;
 						if (reporter === "boxen") {
 							p = import(
-								dirname(new URL(import.meta.url).pathname) +
-									"/reporters/boxen.js"
+								// Node should be ok with this, but transpiling
+								//  to `require` doesn't work, so detect Windows
+								//  to remove slash instead
+								// "file://" +
+								dirname(new URL(import.meta.url).pathname).slice(
+									// istanbul ignore next
+									isWindows ? 1 : 0
+								) + "/reporters/boxen.js"
 							);
 						} else {
-							p = import(pathResolve(process.cwd(), reporter));
+							p = import(
+								// Node should be ok with this, but transpiling
+								//  to `require` doesn't work, so detect Windows
+								//  to remove slash instead
+								// "file://" +
+								pathResolve(process.cwd(), reporter).slice(
+									// istanbul ignore next
+									isWindows ? 1 : 0
+								)
+							);
 						}
 						reporter = (await p).default;
 					}


### PR DESCRIPTION
Fixes #71.

1. Windows compatibility for `import`
1. Avoid need for running `prebuild` (which apparently auto-occurs during install given that [`build`](https://docs.npmjs.com/cli/build) does. `prebuild` wouldn't be run with `npm i --ignore-scripts` anyways.
1. Change `prepublishOnly` to `prepare` to ensure local `npm install` (as from a Git clone) gets the `dist` files built