### PR TITLE
Bump to Node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "lint": "eslint .",
     "test": "nyc ava test/index.test.js",
     "remove-dist": "rimraf dist/*",
-    "pretest": "npm run remove-dist && rollup -c",
-    "prepare": "npm run test"
+    "pretest": "rollup -c",
+    "prepare": "npm run remove-dist && npm run test"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepare": "npm run test"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "repository": {
     "type": "git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,7 +24,7 @@ export default [
 			babel({
 				babelrc: false,
 				plugins: ["@babel/plugin-syntax-import-meta"],
-				presets: [["@babel/preset-env", { targets: { node: 8 } }]],
+				presets: [["@babel/preset-env", { targets: { node: 10 } }]],
 			}),
 			filesize({
 				showBeforeSizes: "release",
@@ -42,7 +42,7 @@ export default [
 			plugins: [
 				babel({
 					babelrc: false,
-					presets: [["@babel/preset-env", { targets: { node: 8 } }]],
+					presets: [["@babel/preset-env", { targets: { node: 10 } }]],
 				}),
 				filesize({
 					showBeforeSizes: "release",


### PR DESCRIPTION
- Breaking changes:
    - Update `engines` to 10.0.0; closes #3
    - Switch Babel targets to Node 10
- npm: Move `remove-dist` to `prepare` so it only runs with `npm i` or `npm publish` and not `npm test` (to allow normally seeing the previous package size)

We could possibly remove `@rollup/plugin-babel` entirely, but it might be good to keep in case: 
1. You need to use any advanced features
2. Your dependencies end up dropping Node 10 support