### PR TITLE
`showBeforeSizes` reporter display fix

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,6 +23,7 @@ export default [
 			json(),
 			babel({
 				babelrc: false,
+				babelHelpers: "bundled",
 				plugins: ["@babel/plugin-syntax-import-meta"],
 				presets: [["@babel/preset-env", { targets: { node: 10 } }]],
 			}),
@@ -42,6 +43,7 @@ export default [
 			plugins: [
 				babel({
 					babelrc: false,
+					babelHelpers: "bundled",
 					presets: [["@babel/preset-env", { targets: { node: 10 } }]],
 				}),
 				filesize({

--- a/src/reporters/boxen.js
+++ b/src/reporters/boxen.js
@@ -22,7 +22,11 @@ export default async function boxenReporter(opt, outputOptions, info) {
 			? [
 					`${title("Bundle Size: ")} ${value(info.bundleSize)} (was ${value(
 						info.bundleSizeBefore
-					)} in version ${info.lastVersion})`,
+					)}${
+						info.lastVersion
+							? ` in version ${info.lastVersion}`
+							: " in last build"
+					})`,
 			  ]
 			: [`${title("Bundle Size: ")} ${value(info.bundleSize)}`]),
 		...(info.minSize
@@ -30,7 +34,11 @@ export default async function boxenReporter(opt, outputOptions, info) {
 				? [
 						`${title("Minified Size: ")} ${value(info.minSize)} (was ${value(
 							info.minSizeBefore
-						)} in version ${info.lastVersion})`,
+						)}${
+							info.lastVersion
+								? ` in version ${info.lastVersion}`
+								: " in last build"
+						})`,
 				  ]
 				: [`${title("Minified Size: ")} ${value(info.minSize)}`]
 			: []),
@@ -39,7 +47,11 @@ export default async function boxenReporter(opt, outputOptions, info) {
 				? [
 						`${title("Gzipped Size: ")} ${value(info.gzipSize)} (was ${value(
 							info.gzipSizeBefore
-						)} in version ${info.lastVersion})`,
+						)}${
+							info.lastVersion
+								? ` in version ${info.lastVersion}`
+								: " in last build"
+						})`,
 				  ]
 				: [`${title("Gzipped Size: ")} ${value(info.gzipSize)}`]
 			: []),
@@ -48,7 +60,11 @@ export default async function boxenReporter(opt, outputOptions, info) {
 				? [
 						`${title("Brotli size: ")}${value(info.brotliSize)} (was ${value(
 							info.brotliSizeBefore
-						)} in version ${info.lastVersion})`,
+						)}${
+							info.lastVersion
+								? ` in version ${info.lastVersion}`
+								: " in last build"
+						})`,
 				  ]
 				: [`${title("Brotli size: ")}${value(info.brotliSize)}`]
 			: []),

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -180,11 +180,42 @@ test("fileSize should apply `showBeforeSizes` option", async (t) => {
 	t.is(existsSync(".cache"), true);
 });
 
+test("fileSize should apply `showBeforeSizes` option with Brotli size", async (t) => {
+	t.timeout(npmNetworkTimeout); // reaching npm may take time on slower network
+	await removeCacheDir();
+
+	const getLoggingData = filesize(
+		{
+			showBeforeSizes: "release",
+			showBrotliSize: true,
+		},
+		"test"
+	);
+	const val = await getLoggingData({ file: "./dist/index.js" }, bundle);
+
+	t.regex(val, /Destination:/);
+
+	t.regex(val, /Brotli size/);
+
+	t.regex(val, /in version/);
+
+	if (colors.supportsColor()) {
+		// eslint-disable-next-line no-control-regex
+		t.regex(val, /\(was \u001b\[33m[\d.]+ KB/);
+	} else {
+		t.regex(val, /\(was [\d.]+ KB/);
+	}
+
+	// Should recreate the `.cache` folder
+	t.is(existsSync(".cache"), true);
+});
+
 test('fileSize should apply `showBeforeSizes` option as "build"', async (t) => {
 	await removeCacheDir();
 
 	const getLoggingData = filesize({ showBeforeSizes: "build" }, "test");
 	const val = await getLoggingData({ file: "./dist/index.js" }, bundle);
+	t.regex(val, /in last build/);
 	if (colors.supportsColor()) {
 		// eslint-disable-next-line no-control-regex
 		t.regex(val, /\(was \u001b\[33m[\d.]+ K?B/);


### PR DESCRIPTION
- Fix: when `showBeforeSizes` is "build", change from `in version undefined` to "in last build"
- Build: Make explicit default `babelHelpers: 'bundled' behavior
