### PR TITLE
- Switch to `babelHelpers: "runtime"`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "homepage": "https://github.com/ritz078/rollup-plugin-filesize#readme",
   "dependencies": {
+    "@babel/runtime": "^7.9.6",
     "boxen": "^4.2.0",
     "brotli-size": "4.0.0",
     "colors": "^1.4.0",
@@ -47,6 +48,7 @@
   "devDependencies": {
     "@babel/core": "^7.9.0",
     "@babel/plugin-syntax-import-meta": "^7.8.3",
+    "@babel/plugin-transform-runtime": "^7.9.6",
     "@babel/preset-env": "^7.9.5",
     "@babel/register": "^7.9.0",
     "@rollup/plugin-babel": "^5.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,8 +23,11 @@ export default [
 			json(),
 			babel({
 				babelrc: false,
-				babelHelpers: "bundled",
-				plugins: ["@babel/plugin-syntax-import-meta"],
+				babelHelpers: "runtime",
+				plugins: [
+					"@babel/plugin-transform-runtime",
+					"@babel/plugin-syntax-import-meta",
+				],
 				presets: [["@babel/preset-env", { targets: { node: 10 } }]],
 			}),
 			filesize({
@@ -40,10 +43,12 @@ export default [
 	},
 	...reporters.map((reporter) => {
 		return {
+			external: ["@babel/runtime"],
 			plugins: [
 				babel({
 					babelrc: false,
-					babelHelpers: "bundled",
+					babelHelpers: "runtime",
+					plugins: ["@babel/plugin-transform-runtime"],
 					presets: [["@babel/preset-env", { targets: { node: 10 } }]],
 				}),
 				filesize({

--- a/yarn.lock
+++ b/yarn.lock
@@ -588,6 +588,16 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
+"@babel/plugin-transform-runtime@^7.9.6":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.9.6.tgz#3ba804438ad0d880a17bca5eaa0cdf1edeedb2fd"
+  integrity sha512-qcmiECD0mYOjOIt8YHNsAP1SxPooC/rDmfmiSK9BNY72EitdSc7l44WTEklaWuFtbOEBjNhWWyph/kOImbNJ4w==
+  dependencies:
+    "@babel/helper-module-imports" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
+    resolve "^1.8.1"
+    semver "^5.5.1"
+
 "@babel/plugin-transform-shorthand-properties@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz#28545216e023a832d4d3a1185ed492bcfeac08c8"
@@ -725,6 +735,13 @@
   version "7.9.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
   integrity sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.9.6":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.6.tgz#a9102eb5cadedf3f31d08a9ecf294af7827ea29f"
+  integrity sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -4253,7 +4270,7 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-resolve@^1.10.0, resolve@^1.12.0, resolve@^1.3.2:
+resolve@^1.10.0, resolve@^1.12.0, resolve@^1.3.2, resolve@^1.8.1:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==


### PR DESCRIPTION
This PR only makes a very minor difference in filesize:

**dist/index.js**:
5.37 KB (was 5.41 KB in last build)

**dist/reporters/boxen.js**:
1.77 KB (was 1.8 KB in last build) 

...but since "runtime" is the [option recommended for Rollup libraries](https://github.com/rollup/plugins/tree/master/packages/babel#babelhelpers), and since this plugin is particularly concerned with filesize, I figured you might want to switch.

Note, however, that besides adding a devDep, this PR adds a regular dependency (though which may be required by other projects too), so the resulting package size may actually be larger as a result in cases where the dep. is not already being used. If you don't want the PR, feel free to close; I just wanted to draw attention to the fact that the `babelHelpers` option could be set to this value instead.

(Btw, here was a case where `showbeforeSizes: "build"` was useful (I used it temporarily, though switched back before sending this PR), as I could see the difference from that just on `master` rather than compared to the past release.)

![image](https://user-images.githubusercontent.com/20234/81626242-b4718880-942d-11ea-959b-1b0cb558862b.png)
