### PR TITLE
Add type declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,43 @@
+import { Plugin, OutputOptions } from "rollup";
+import { partial } from "filesize";
+
+export interface FileSizeInfo {
+	minSize: string;
+	gzipSize: string;
+	brotliSize: string;
+	bundleSize: string;
+	fileName: string;
+	lastVersion?: string;
+	bundleSizeBefore?: string;
+	brotliSizeBefore?: string;
+	minSizeBefore?: string;
+	gzipSizeBefore?: string;
+}
+
+export type FileSizeRender<T> = (
+	options: FileSizeOptions,
+	outputOptions: OutputOptions,
+	info: FileSizeInfo
+) => T;
+
+export interface FileSizeOptions {
+	showMinifiedSize?: boolean;
+	showGzippedSize?: boolean;
+	showBrotliSize?: boolean;
+	showBeforeSizes?: "release" | "build" | "none";
+	format?: Parameters<typeof partial>[0];
+	render?: FileSizeRender<string>;
+	theme?: "dark" | "light";
+}
+
+export type FileSizeReporter =
+	| "boxen"
+	| FileSizeRender<string | Promise<string>>;
+
+export interface FileSizePluginOptions extends FileSizeOptions {
+	reporter?: FileSizeReporter | FileSizeReporter[];
+}
+
+declare const filesize: (options?: FileSizePluginOptions) => Plugin;
+
+export default filesize;

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
   "files": [
     "src",
     "dist",
+    "index.d.ts",
     "README",
     "!.DS_Store",
     "!.nyc_output"
   ],
+  "typings": "./index.d.ts",
   "scripts": {
     "lint": "eslint .",
     "test": "nyc ava test/index.test.js",


### PR DESCRIPTION
I created a declaration file for `rollup-plugin-filesize` to use in rollup config of some of personal projects and thought it would be nice to share it with others. Hope that you (owners and maintainers) will review and consider to merge this PR so that everyone will get IntelliSense support.