### PR TITLE
Update terser to 5.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "filesize": "^6.1.0",
     "gzip-size": "^5.1.1",
     "pacote": "^11.1.10",
-    "terser": "^4.8.0"
+    "terser": "^5.5.1"
   },
   "devDependencies": {
     "@babel/core": "^7.10.3",

--- a/src/index.js
+++ b/src/index.js
@@ -92,7 +92,7 @@ export default function filesize(options = {}, env) {
 			: "";
 
 		if (showMinifiedSize || showGzippedSize) {
-			const minifiedCode = terser.minify(code).code;
+			const minifiedCode = (await terser.minify(code)).code;
 			info.minSize = showMinifiedSize
 				? fileSize(minifiedCode.length, format)
 				: "";
@@ -107,7 +107,7 @@ export default function filesize(options = {}, env) {
 				? fileSize(await brotli(codeBefore), format)
 				: "";
 			if (showMinifiedSize || showGzippedSize) {
-				const minifiedCode = terser.minify(codeBefore).code;
+				const minifiedCode = (await terser.minify(codeBefore)).code;
 				info.minSizeBefore = showMinifiedSize
 					? fileSize(minifiedCode.length, format)
 					: "";

--- a/test/fixtures/sample.js
+++ b/test/fixtures/sample.js
@@ -1,1 +1,3 @@
 console.log("test");
+let foo;
+foo ??= 'a';


### PR DESCRIPTION
This fixes #87 and adds support for optional chaining and nullish coalescing.