### PR TITLE
fix: pin colors@1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@babel/runtime": "^7.13.8",
     "boxen": "^5.0.0",
     "brotli-size": "4.0.0",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "filesize": "^6.1.0",
     "gzip-size": "^6.0.0",
     "pacote": "^11.2.7",


### PR DESCRIPTION
A Security Vuln was identified in the Colors package for >1.4.0, offending packages being `1.4.1`, `1.4.44-liberty`
- [source1](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source2](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source3](https://security.snyk.io/vuln/SNYK-JS-COLORS-2331906)

This PR pins the color package to `1.4.0` as advised on the [snyk page](https://snyk.io/blog/open-source-maintainer-pulls-the-plug-on-npm-packages-colors-and-faker-now-what/)